### PR TITLE
Set project before login

### DIFF
--- a/docker/google-base/destroy_citc.py
+++ b/docker/google-base/destroy_citc.py
@@ -131,6 +131,9 @@ def run_everything(args):
     if dry:
         print("*** DRY RUN ***\n\n")
 
+    if not has_completed("gcloud_set_project"):
+        run_command(f"gcloud config set project {project}")
+
     if not has_completed("gcloud_login"):
         run_command("gcloud auth login")
 
@@ -156,9 +159,6 @@ def run_everything(args):
         project = str(data["project"])
 
     print(f"Destroying the cluster called {cluster_name} in project {project}")
-
-    if not has_completed("gcloud_set_project"):
-        run_command(f"gcloud config set project {project}")
 
     if not has_completed("gcloud_enable_services"):
         run_command(f"gcloud services enable compute.googleapis.com "

--- a/docker/google-base/install_citc.py
+++ b/docker/google-base/install_citc.py
@@ -245,11 +245,11 @@ def run_everything(args):
             os.chdir("citc-terraform")
             print(os.getcwd())
 
-    if not has_completed("gcloud_login"):
-        run_command("gcloud auth login")
-
     if not has_completed("gcloud_set_project"):
         run_command(f"gcloud config set project {project}")
+
+    if not has_completed("gcloud_login"):
+        run_command("gcloud auth login")
 
     if not has_completed("gcloud_enable_services"):
         run_command(f"gcloud services enable compute.googleapis.com "


### PR DESCRIPTION
Move the
    gcloud config set project {project}
before the
    gcloud auth login

so as to avoid the error
    ERROR: (gcloud.auth.login) The project property is set to the empty string, which is invalid.