### PR TITLE
produce clean error message on missing argument to install-citc.sh

### DIFF
--- a/install-citc.sh
+++ b/install-citc.sh
@@ -1,6 +1,11 @@
 #! /bin/sh
 set -eu
 
+if [ $# -ne 1 ]; then
+    echo "ERROR: Usage: ${0} <cloud_provider>" >&2
+    exit 1
+fi
+
 PYTHON="$(command -v python3 || command -v python)"
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 "${PYTHON}" "${DIR}/install-citc.py" "${@}"


### PR DESCRIPTION
Before:

```
$ ./install-citc.sh
./install-citc.sh: line 6: @: unbound variable
```

after:

```
$ ./install-citc.sh
ERROR: Usage: ./install-citc.sh <cloud_provider>
```